### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ OTHERCXXFLAGS := -std=c++11
 
 # PKG Asset directories
 ASSETS        :=
-SCEMODULES    := $(shell find sce_module/ -type f -name '*.*')
-SCESYS        := $(shell find sce_sys/ -type f -name '*.*')
+SCEMODULES    := $(shell find sce_module -type f -name '*.*')
+SCESYS        := $(shell find sce_sys -type f -name '*.*')
 
 # -----------------------------------------------------------------------------
 # Do not edit below this line unless you know what you are doing


### PR DESCRIPTION
This change fixes a PkgTool build error on macOS:

```
/opt/OpenOrbis-PS4-Toolchain/bin/macos/create-gp4 -out pkg.gp4 --content-id=IV0000-AZIF00000_00-SKELETON00000000 --files "eboot.bin sce_sys/param.sfo sce_sys//about/right.sprx sce_sys//pic0.png sce_sys//icon0.png sce_sys//pic1.png sce_module//libc.prx sce_module//libLog.prx sce_module//libjbc.prx sce_module//libSceFios2.prx"
/opt/OpenOrbis-PS4-Toolchain/bin/macos/PkgTool.Core pkg_build pkg.gp4 .
Unhandled exception. System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at LibOrbisPkg.PFS.PfsProperties.FindDir(String name, FSDir root)
   at LibOrbisPkg.PFS.PfsProperties.BuildFSTree(Gp4Project proj, String projDir)
   at LibOrbisPkg.PKG.PkgProperties.FromGp4(Gp4Project project, String projDir)
   at PkgTool.Program.<>c.<.cctor>b__6_2(String[] args)
   at PkgTool.Verb.<>c__DisplayClass4_0.<Create>b__0(Dictionary`2 _, Dictionary`2 _2, String[] a)
   at PkgTool.Verb.Run(Verb[] verbs, String[] args, String name)
   at PkgTool.Program.Main(String[] args)
make: *** [IV0000-AZIF00000_00-SKELETON00000000.pkg] Abort trap: 6
```